### PR TITLE
Remove with roles elequent query

### DIFF
--- a/src/Resources/UserResource.php
+++ b/src/Resources/UserResource.php
@@ -143,11 +143,6 @@ class UserResource extends Resource
         ];
     }
 
-    public static function getEloquentQuery(): Builder
-    {
-        return parent::getEloquentQuery()->with('roles');
-    }
-
     public static function getUserTimezone(): string
     {
         return config('request.user.timezone', config('filament-authentication.user_timezone', config('app.timezone', 'UTC')));


### PR DESCRIPTION
While editing a user with a role, the following error occours

```
Illuminate \ Database \ QueryException
SQLSTATE[HY093]: Invalid parameter number
select `name`, `id` from `roles` where `id` in (1)
```


Removing
```
src/Resources/UserResource.php: 147

public static function getEloquentQuery(): Builder
{
    return parent::getEloquentQuery()->with('roles');
}
```

And the edit page of a user works fine.

```
Versions
Laravel Version 9.10.1
Laravel Locale en

Laravel Config Cached false
App Debug true
App Env local
Php Version 8.1.5
```
