### PR TITLE
Remove duplicate closing bracket

### DIFF
--- a/resources/views/filament/pages/profile.blade.php
+++ b/resources/views/filament/pages/profile.blade.php
@@ -4,7 +4,7 @@
 
         <div class="flex flex-wrap items-center gap-4 justify-end">
             <x-filament::button type="submit">
-            {{ __('filament::resources/pages/edit-record.form.actions.save.label')) }}
+            {{ __('filament::resources/pages/edit-record.form.actions.save.label') }}
             </x-filament::button>
 
 


### PR DESCRIPTION
Removes the extra closing bracket from the profile page. Profile page won't load otherwise. 

admin/profile
```
PHP 8.1.5
Laravel 9.10.1

Unmatched ')'
```