### PR TITLE
Add a trait for page policy and settings page policy

### DIFF
--- a/src/Traits/PagePolicyTrait.php
+++ b/src/Traits/PagePolicyTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Phpsa\FilamentAuthentication\Traits;
+
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Gate;
+
+trait PagePolicyTrait
+{
+    public static function mount(): void
+    {
+        abort_unless(static::canView(), 403);
+    }
+
+    protected static function canView(): bool
+    {
+        if (static::getPolicy() == null) {
+            return true;
+        }
+
+        return static::getPolicy()->viewAny(Filament::auth()->user());
+    }
+
+    protected static function shouldRegisterNavigation(): bool
+    {
+        return static::canView() && static::$shouldRegisterNavigation;
+    }
+
+    protected static function getPolicy()
+    {
+        return Gate::getPolicyFor(static::class);
+    }
+}

--- a/src/Traits/SettingsPagePolicyTrait.php
+++ b/src/Traits/SettingsPagePolicyTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Phpsa\FilamentAuthentication\Traits;
+
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Gate;
+
+trait SettingsPagePolicyTrait
+{
+    public function mount(): void
+    {
+        abort_unless(static::canView(), 403);
+
+        parent::mount();
+    }
+
+    protected static function canView(): bool
+    {
+        if (static::getPolicy() == null) {
+            return false;
+        }
+
+        return static::getPolicy()->viewAny(Filament::auth()->user());
+    }
+
+    protected static function shouldRegisterNavigation(): bool
+    {
+        return static::canView() && static::$shouldRegisterNavigation;
+    }
+
+    protected static function getPolicy()
+    {
+        return Gate::getPolicyFor(static::class);
+    }
+}


### PR DESCRIPTION
Adds traits to extend policies to Filament pages and Filament Setting Pages

```php
# Filament Pages policy trait
use PagePolicyTrait;

# Fileament Settings Pages policy trait
use SettingsPagePolicyTrait;
```

Example usage on Filament Page:
```php
use Filament\Pages\Page;
use Phpsa\FilamentAuthentication\Traits\PagePolicyTrait;

class TestPage extends Page
{
    use PagePolicyTrait;

    protected static ?string $navigationIcon = 'heroicon-o-document-text';
    protected static string $view = 'filament.pages.test-page';
}
```

Example usage on Filament Settings Page
```php
use App\Settings\TestSettings;
use Filament\Forms\Components\Checkbox;
use Filament\Forms\Components\TextInput;
use Filament\Pages\SettingsPage;
use Phpsa\FilamentAuthentication\Traits\SettingsPagePolicyTrait;

class ManageSettings extends SettingsPage
{
    use SettingsPagePolicyTrait;

    protected static string $settings = TestSettings::class;
    protected static ?string $navigationGroup = 'Test';
    protected static ?string $navigationIcon = 'heroicon-o-cog';

    protected function getFormSchema(): array
    {
        return [
            TextInput::make('site_name')->label('Site name'),
            Checkbox::make('site_active')
                ->label('Enable site')
        ];
    }
}
```

Link your page together with the policy to `$policies = [];`.
