### PR TITLE
Make Role and Permission Name and Guard Name required for form

### DIFF
--- a/src/Resources/PermissionResource.php
+++ b/src/Resources/PermissionResource.php
@@ -55,10 +55,12 @@ class PermissionResource extends Resource
                     ->schema([
                         Grid::make(2)->schema([
                             TextInput::make('name')
+                                ->required()
                                 ->label(strval(__('filament-authentication::filament-authentication.field.name'))),
                             TextInput::make('guard_name')
+                                ->required()
                                 ->label(strval(__('filament-authentication::filament-authentication.field.guard_name')))
-                                 ->default(config('auth.defaults.guard')),
+                                ->default(config('auth.defaults.guard')),
                             // BelongsToManyMultiSelect::make('roles')
                             //     ->label(strval(__('filament-authentication::filament-authentication.field.roles')))
                             //     ->relationship('roles', 'name')

--- a/src/Resources/RoleResource.php
+++ b/src/Resources/RoleResource.php
@@ -52,9 +52,11 @@ class RoleResource extends Resource
                         Grid::make(2)
                             ->schema([
                                 TextInput::make('name')
-                                    ->label(strval(__('filament-authentication::filament-authentication.field.name'))),
+                                    ->label(strval(__('filament-authentication::filament-authentication.field.name')))
+                                    ->required(),
                                 TextInput::make('guard_name')
                                     ->label(strval(__('filament-authentication::filament-authentication.field.guard_name')))
+                                    ->required()
                                     ->default(config('auth.defaults.guard')),
                                 // BelongsToManyMultiSelect::make('permissions')
                                 //     ->label(strval(__('filament-authentication::filament-authentication.field.permissions')))


### PR DESCRIPTION
Hi Craig! 

I Suggesting to make name of the role and the guard name as a required field to prevent sql error.

Good Job of this package