### PR TITLE
fix: Add password type to input password

### DIFF
--- a/src/Pages/Profile.php
+++ b/src/Pages/Profile.php
@@ -116,6 +116,7 @@ class Profile extends Page
                         ->schema([
                             TextInput::make('new_password')
                                 ->label('New Password')
+                                ->password()
                                 ->rules(['confirmed', Password::defaults()])
                                 ->autocomplete('new-password'),
                             TextInput::make('new_password_confirmation')


### PR DESCRIPTION
The profile page input password don`t has password type
![image](https://user-images.githubusercontent.com/39275291/232118449-6e959d61-132c-4a02-87f4-1a2a427ba67a.png)
