### PR TITLE
feat(widgets): update LatestUsers query to use the configured resource

### DIFF
--- a/config/filament-authentication.php
+++ b/config/filament-authentication.php
@@ -18,7 +18,8 @@ return [
         'LatestUsers' => [
             'enabled' => true,
             'limit'   => 5,
-            'sort'    => 0
+            'sort'    => 0,
+            'paginate' => false
         ],
     ],
     'preload_roles' => true,

--- a/src/Widgets/LatestUsersWidget.php
+++ b/src/Widgets/LatestUsersWidget.php
@@ -11,11 +11,9 @@ class LatestUsersWidget extends TableWidget
 {
     protected function getTableQuery(): Builder
     {
-        $userClass = config('filament-authentication.models.User');
-
-        return $userClass::query()
-        ->latest()
-        ->limit(Config::get('filament-authentication.Widgets.LatestUsers.limit'));
+        return $this->getResource()::getEloquentQuery()
+            ->latest()
+            ->limit(Config::get('filament-authentication.Widgets.LatestUsers.limit'));
     }
 
     protected function getTableColumns(): array

--- a/src/Widgets/LatestUsersWidget.php
+++ b/src/Widgets/LatestUsersWidget.php
@@ -31,7 +31,7 @@ class LatestUsersWidget extends TableWidget
 
     protected function isTablePaginationEnabled(): bool
     {
-        return false;
+        return Config::get('filament-authentication.Widgets.LatestUsers.paginate', false)
     }
 
     public static function canView(): bool


### PR DESCRIPTION
The LatestUsers widget will now default to using the configured resource so that it inherits any query updates done upstream via `getEloquentQuery()`.